### PR TITLE
chore: stitches 세팅

### DIFF
--- a/app/index.css
+++ b/app/index.css
@@ -1,1 +1,9 @@
 @layer reset, base, tokens, recipes, utilities;
+
+body {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: Noto Sans KR, sans-serif;
+  font-weight: 500;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,6 +5,7 @@ import { ApolloProvider } from "@apollo/client/index.js";
 import apolloClient from "src/apollo/client";
 
 import styles from "./index.css?url";
+import { getCssText } from "src/stitches";
 
 export const links: LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -28,6 +29,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
+        <style id="stitches" dangerouslySetInnerHTML={{ __html: getCssText() }} />
       </head>
       <body>
         {children}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -15,7 +15,7 @@ export const links: LinksFunction = () => [
   },
   {
     rel: "stylesheet",
-    href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
+    href: "https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap",
   },
   { rel: "stylesheet", href: styles },
 ];

--- a/src/stitches.ts
+++ b/src/stitches.ts
@@ -1,6 +1,6 @@
 import { createStitches } from "@stitches/react";
 
-export const { styled, css } = createStitches({
+export const { styled, css, getCssText } = createStitches({
   theme: {
     colors: {
       primary: "#DE4B18",

--- a/src/stitches.ts
+++ b/src/stitches.ts
@@ -1,0 +1,23 @@
+import { createStitches } from "@stitches/react";
+
+export const { styled, css } = createStitches({
+  theme: {
+    colors: {
+      primary: "#DE4B18",
+      black: "#12100E",
+      white: "#F7F6F4",
+
+      warmGray50: "#F7F6F4",
+      warmGray100: "#EFEDEA",
+      warmGray200: "#D9D5CE",
+      warmGray300: "#C4BDB2",
+      warmGray400: "#AFA597",
+      warmGray500: "#998D7B",
+      warmGray600: "#766F69",
+      warmGray700: "#655B4E",
+      warmGray800: "#494238",
+      warmGray900: "#2E2923",
+      warmGray950: "#12100E",
+    },
+  },
+});


### PR DESCRIPTION
## 1. SSR 세팅 
Zero run time의 기능을 사용하기 위한 SSR 세팅 완료.

### SSR 적용 전 하이드레이션 이전 스타일이 적용되지 않는다.
https://github.com/user-attachments/assets/db9acf16-3f95-4475-9635-57302069cc6a

### SSR 적용 후 하이드레이션 이전 정적 스타일이 적용된다.
https://github.com/user-attachments/assets/c7b615e5-0a23-4cdb-b4fc-f26fdf6503e7

## 2. Noto Sans KR 폰트 적용 필요.
현재 폰트를 정상적으로 불러오지만, Link 태그를 통해 요청을 보내고, 하이드리에션 이전 폰트가 적용되지 않습니다. 이 부분은 추가적으로 이슈를 파면 좋을 듯 합니다.

## 3. Stitches theme token 적용.
Stitches의 테마 기능을 사용하기 위해서 `src/stitches.ts` 파일에 설정을 할 수 있습니다.
자세한 사항은 공식문서를 참고해주세요.
https://stitches.dev/docs/tokens