### PR TITLE
feat: LogPreview 컴포넌트 구현 및 stitches, storybook 세팅

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  stories: ["../app/**/*.mdx", "../app/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: [
     "@storybook/addon-onboarding",
     "@storybook/addon-essentials",

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,5 @@
+<!-- Or you can load custom head-tag JavaScript: -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap" />
+<link rel="stylesheet" href="../app/index.css" />

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,6 @@
 import type { Preview } from "@storybook/react";
+import { globalStyles } from "../src/stitches";
+import React from "react";
 
 const preview: Preview = {
   parameters: {
@@ -9,6 +11,12 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [
+    (Stroy) => {
+      globalStyles();
+      return <Stroy />;
+    },
+  ],
 };
 
 export default preview;

--- a/app/component/Image/Image.stories.tsx
+++ b/app/component/Image/Image.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Image from ".";
+
+const meta: Meta<typeof Image> = {
+  title: "Components/Image",
+  component: Image,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: `Image 컴포넌트는 이미지 로드, 로딩 중, 에러 상태를 처리할 수 있는 확장된 HTML 이미지 컴포넌트입니다.`,
+      },
+    },
+  },
+  argTypes: {
+    isLoading: {
+      control: "boolean",
+      description: "이미지가 로딩 중인지 여부를 나타냅니다.",
+    },
+    isError: {
+      control: "boolean",
+      description: "이미지가 로드되지 않아 에러 상태인지 여부를 나타냅니다.",
+    },
+    src: {
+      control: "text",
+      description: "이미지 URL",
+    },
+    alt: {
+      control: "text",
+      description: "이미지 설명 (대체 텍스트)",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "200px", height: "200px", display: "flex", justifyContent: "center", alignItems: "center" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const LoadingState: Story = {
+  name: "로딩 중 상태",
+  args: {
+    isLoading: true,
+    src: "https://via.placeholder.com/200",
+    alt: "로딩 중인 이미지",
+  },
+};
+
+export const LoadedState: Story = {
+  name: "로딩 완료 상태",
+  args: {
+    isLoading: false,
+    isError: false,
+    src: "https://via.placeholder.com/200",
+    alt: "이미지가 로드된 상태",
+  },
+};
+
+export const ErrorState: Story = {
+  name: "에러 상태",
+  args: {
+    isError: true,
+    src: "",
+    alt: "에러 상태의 이미지",
+  },
+};

--- a/app/component/Image/index.tsx
+++ b/app/component/Image/index.tsx
@@ -1,0 +1,11 @@
+import { ImgHTMLAttributes } from "react";
+import S from "./style";
+
+interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
+  isLoading?: boolean;
+  isError?: boolean;
+}
+
+export default function Image(props: ImageProps) {
+  return props.isError ? <S.Image {...props} alt="props" /> : null;
+}

--- a/app/component/Image/index.tsx
+++ b/app/component/Image/index.tsx
@@ -7,6 +7,9 @@ interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   isError?: boolean;
 }
 
-export default function Image(props: ImageProps) {
-  return props.isError ? <BiSolidError size={"50%"} /> : props.src ? <S.Image {...props} /> : null;
+export default function Image({ isError, ...props }: ImageProps) {
+  if (isError) {
+    return <BiSolidError size={"50%"} />;
+  }
+  return props.src ? <S.Image {...props} /> : null;
 }

--- a/app/component/Image/index.tsx
+++ b/app/component/Image/index.tsx
@@ -1,5 +1,6 @@
 import { ImgHTMLAttributes } from "react";
 import S from "./style";
+import { BiSolidError } from "react-icons/bi";
 
 interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   isLoading?: boolean;
@@ -7,5 +8,5 @@ interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
 }
 
 export default function Image(props: ImageProps) {
-  return props.isError ? <S.Image {...props} alt="props" /> : null;
+  return props.isError ? <BiSolidError size={"50%"} /> : props.src ? <S.Image {...props} /> : null;
 }

--- a/app/component/Image/style.ts
+++ b/app/component/Image/style.ts
@@ -1,0 +1,32 @@
+import { keyframes } from "@stitches/react";
+import { styled } from "src/stitches";
+
+const skeletonAnimation = keyframes({
+  "0%": { backgroundPosition: "200% 0" },
+  "100%": { backgroundPosition: "-200% 0" },
+});
+
+const Image = styled("img", {
+  width: "100%",
+  height: "100%",
+  objectFit: "cover",
+
+  variants: {
+    isLoading: {
+      true: {
+        background: "linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%)",
+        backgroundSize: "200% 100%",
+        animation: `${skeletonAnimation} 1.5s infinite`,
+        opacity: 0.5,
+      },
+      false: {
+        background: "none",
+        opacity: 1,
+      },
+    },
+  },
+});
+
+const S = { Image };
+
+export default S;

--- a/app/component/LogPreview/LogPreview.stories.tsx
+++ b/app/component/LogPreview/LogPreview.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import LogPreview from ".";
+
+const meta: Meta<typeof LogPreview> = {
+  title: "Components/LogPreview",
+  component: LogPreview,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "LogPreview 컴포넌트는 장소, 제목, 이미지 URL을 받아 간단한 콘텐츠 프리뷰를 보여줍니다.",
+      },
+    },
+  },
+  argTypes: {
+    place: {
+      control: "text",
+      description: "LogPreview의 위치 텍스트",
+    },
+    title: {
+      control: "text",
+      description: "LogPreview의 제목 텍스트",
+    },
+    imageUrl: {
+      control: "text",
+      description: "프리뷰에 표시할 이미지 URL",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "100vw", maxWidth: "500px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: "기본 상태",
+  args: {
+    place: "단일커피",
+    title: "아이스 아메리카노",
+    imageUrl: "https://via.placeholder.com/60",
+  },
+};
+
+export const NoImage: Story = {
+  name: "이미지가 없는 상태",
+  args: {
+    place: "홈 카페",
+    title: "진짜 맛있게 내린 홈 브루잉 커피",
+    imageUrl: "",
+  },
+};

--- a/app/component/LogPreview/LogPreview.stories.tsx
+++ b/app/component/LogPreview/LogPreview.stories.tsx
@@ -53,6 +53,5 @@ export const NoImage: Story = {
   args: {
     place: "홈 카페",
     title: "진짜 맛있게 내린 홈 브루잉 커피",
-    imageUrl: "",
   },
 };

--- a/app/component/LogPreview/index.tsx
+++ b/app/component/LogPreview/index.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import S from "./style";
+import Image from "../Image";
+
+interface LogPreviewProps {
+  place: string;
+  title: string;
+  imageUrl: string;
+}
+
+export default function LogPreview({ place, title, imageUrl }: LogPreviewProps) {
+  const [isLoading, setIsLoading] = useState(!!imageUrl);
+  const [isError, setIsError] = useState(false);
+
+  return (
+    <S.Container>
+      <S.InfoContainer>
+        <S.Place>{place}</S.Place>
+        <S.Title>{title}</S.Title>
+      </S.InfoContainer>
+      <S.ImageContainer>
+        <Image
+          src={imageUrl}
+          isLoading={isLoading}
+          isError={isError}
+          onLoad={() => setIsLoading(false)}
+          onError={() => setIsError(true)}
+          alt={`${title} 이미지`}
+        />
+      </S.ImageContainer>
+    </S.Container>
+  );
+}

--- a/app/component/LogPreview/index.tsx
+++ b/app/component/LogPreview/index.tsx
@@ -5,7 +5,7 @@ import Image from "../Image";
 interface LogPreviewProps {
   place: string;
   title: string;
-  imageUrl: string;
+  imageUrl?: string;
 }
 
 export default function LogPreview({ place, title, imageUrl }: LogPreviewProps) {

--- a/app/component/LogPreview/style.ts
+++ b/app/component/LogPreview/style.ts
@@ -1,0 +1,33 @@
+import { styled } from "src/stitches";
+
+const Container = styled("div", {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+
+  padding: "14px 20px",
+  width: "100%",
+  height: "90px",
+  borderBottom: "1px solid $warmGray300",
+});
+
+const InfoContainer = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  gap: "2px",
+});
+
+const Place = styled("p", {});
+
+const Title = styled("h3", {});
+
+const ImageContainer = styled("div", {
+  width: "60px",
+  height: "60px",
+  borderRadius: "2px",
+  overflow: "hidden",
+});
+
+const S = { Container, InfoContainer, Place, Title, ImageContainer };
+
+export default S;

--- a/app/index.css
+++ b/app/index.css
@@ -1,9 +1,170 @@
 @layer reset, base, tokens, recipes, utilities;
 
-body {
+/* 기본 초기화 CSS */
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
   margin: 0;
   padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+
+/* HTML5 요소 초기화 */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+
+body {
+  line-height: 1.5;
+  background-color: #fff; /* 기본 배경색 */
+  color: #333; /* 기본 텍스트 색상 */
+  font-family: Arial, sans-serif; /* 기본 폰트 */
+}
+
+/* 리스트 스타일 제거 */
+ol,
+ul {
+  list-style: none;
+}
+
+/* 테이블 기본 스타일 초기화 */
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+/* 하이퍼링크 스타일 초기화 */
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+/* 이미지 기본 스타일 초기화 */
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* 버튼 초기화 */
+button {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+}
+
+/* 입력 요소 초기화 */
+input,
+textarea {
+  font: inherit;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+}
+
+/* 전역 박스 크기 설정 */
+*,
+*::before,
+*::after {
   box-sizing: border-box;
-  font-family: Noto Sans KR, sans-serif;
-  font-weight: 500;
+}
+
+/* 스크롤바 숨기기 (선택 사항) */
+::-webkit-scrollbar {
+  width: 0;
+  height: 0;
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,7 +5,7 @@ import { ApolloProvider } from "@apollo/client/index.js";
 import apolloClient from "src/apollo/client";
 
 import styles from "./index.css?url";
-import { getCssText } from "src/stitches";
+import { getCssText, globalStyles } from "src/stitches";
 
 export const links: LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -22,6 +22,7 @@ export const links: LinksFunction = () => [
 ];
 
 export function Layout({ children }: { children: React.ReactNode }) {
+  globalStyles();
   return (
     <html lang="en">
       <head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "graphql": "^16.9.0",
         "isbot": "^4.1.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-icons": "^5.4.0"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.2",
@@ -12355,6 +12356,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "graphql": "^16.9.0",
     "isbot": "^4.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-icons": "^5.4.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.2",

--- a/src/stitches.ts
+++ b/src/stitches.ts
@@ -1,4 +1,4 @@
-import { createStitches } from "@stitches/react";
+import { createStitches, globalCss } from "@stitches/react";
 
 export const { styled, css, getCssText } = createStitches({
   theme: {
@@ -19,5 +19,52 @@ export const { styled, css, getCssText } = createStitches({
       warmGray900: "#2E2923",
       warmGray950: "#12100E",
     },
+  },
+});
+
+export const globalStyles = globalCss({
+  body: {
+    fontFamily: "Noto Sans KR, sans-serif",
+    color: "$black",
+  },
+  "h1, .heading1": {
+    fontSize: "32px",
+    lineHeight: "140%",
+    fontWeight: 900,
+  },
+  "h2, .heading2": {
+    fontSize: "26px",
+    lineHeight: "130%",
+    fontWeight: 700,
+  },
+  "h3, .heading3": {
+    fontSize: "22px",
+    lineHeight: "120%",
+    fontWeight: 500,
+  },
+  "h4, .heading4": {
+    fontSize: "20px",
+    lineHeight: "130%",
+    fontWeight: 500,
+  },
+  "h5, .heading5": {
+    fontSize: "18px",
+    lineHeight: "130%",
+    fontWeight: 500,
+  },
+  "p, .font-base": {
+    fontSize: "16px",
+    lineHeight: "130%",
+    fontWeight: 400,
+  },
+  ".font-small": {
+    fontSize: "14px",
+    lineHeight: "130%",
+    fontWeight: 400,
+  },
+  ".font-xsmall": {
+    fontSize: "12px",
+    lineHeight: "130%",
+    fontWeight: 400,
   },
 });


### PR DESCRIPTION
LogPreview를 만드는 이슈로 시작하였으나, 간단하고 기본적인 세팅은 같이 진행하였습니다.

## 1. globalCss를 이용하여 font token구성
heading에 대한 스타일은 오버라이딩 하였고, 다른 스타일은 calssName에 넣으면 적용됩니다.
[font token 코드 보기](https://github.com/Daily-Drip-Dev/Daily-Drip/pull/7/files#diff-2615a9d7ae8f02e44224c7536d9b305f0d68911421ac0391ddbe7fe1216e7980)

## 2. preview-head.html을 이용한 storybook 세팅
스토리북에선 공통 스타일이 적용되지 않았고, 이를 적용하기 위해 preview-head.html에서 link 속성을 이용해 가져왔습니다.
이를 통해 google 폰트 역시 설정하였습니다.
[Storybook 코드 보기](https://github.com/Daily-Drip-Dev/Daily-Drip/pull/7/files#diff-22bfa436a490448858048de4423952a0f8db74eb9667a997e5af2cf1d2c94a38)
[Storybook preview-head.html 공식 문서](https://storybook.js.org/docs/configure/story-rendering#adding-to-head)

## 3. Image 컴포넌트 구현
기존 Image컴포넌트에 isLoading과 isError를 넣은 간단한 공통 컴포넌트를 구현해봤습니다.
### state를 이용한 Stitches의 동적 스타일링 사용법
```
const Image = styled("img", {
  width: "100%",
  height: "100%",
  objectFit: "cover",

  variants: {
    isLoading: {
      true: {
        background: "linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%)",
        backgroundSize: "200% 100%",
        animation: `${skeletonAnimation} 1.5s infinite`,
        opacity: 0.5,
      },
      false: {
        background: "none",
        opacity: 1,
      },
    },
  },
});
```
variants를 사용하여 구현할 수 있습니다.

## 4. LogPreview 컴포넌트 구현
ㅈㄱㄴ