### PR TITLE
feat: HomeHeader 컴포넌트 구현

### DIFF
--- a/app/component/HomeHeader/HomeHeader.stories.tsx
+++ b/app/component/HomeHeader/HomeHeader.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import HomeHeader from ".";
+
+const meta: Meta<typeof HomeHeader> = {
+  title: "Components/HomeHeader",
+  component: HomeHeader,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "HomeHeader 컴포넌트는 페이지 헤더로, 제목과 아이콘 버튼을 포함합니다.",
+      },
+    },
+  },
+  argTypes: {
+    onIconClick: {
+      action: "clicked",
+      description: "아이콘 버튼이 클릭되었을 때 호출되는 함수입니다.",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "450px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: "기본 상태",
+  args: {
+    children: "My Logs",
+    onIconClick: () => alert("아이콘 버튼 클릭"),
+  },
+};

--- a/app/component/HomeHeader/index.tsx
+++ b/app/component/HomeHeader/index.tsx
@@ -1,0 +1,20 @@
+import { PropsWithChildren } from "react";
+import { MdAdd } from "react-icons/md";
+import S from "./style";
+
+interface HomeHeaderProps extends PropsWithChildren {
+  onIconClick: () => void;
+}
+
+export default function HomeHeader({ children, onIconClick }: HomeHeaderProps) {
+  return (
+    <S.Container>
+      <h1>{children}</h1>
+      <S.IconWrapper>
+        <S.RightButton onClick={onIconClick}>
+          <MdAdd size={48} />
+        </S.RightButton>
+      </S.IconWrapper>
+    </S.Container>
+  );
+}

--- a/app/component/HomeHeader/style.ts
+++ b/app/component/HomeHeader/style.ts
@@ -1,0 +1,26 @@
+import { styled } from "src/stitches";
+
+const Container = styled("div", {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+
+  padding: "0 12px",
+  width: "100%",
+});
+
+const IconWrapper = styled("div", {
+  padding: "0px 16px",
+});
+
+const RightButton = styled("button", {
+  color: "$black",
+
+  "& > svg": {
+    verticalAlign: "middle",
+  },
+});
+
+const S = { Container, IconWrapper, RightButton };
+
+export default S;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f3382383-cb64-4be4-ad51-37e2a1e4ceb9)

#8

### 1. children, onIconClick 을 입력받는 HomeHeader 컴포넌트 구현. 

### 2. svg에 다음 css코드 추가
**문제**
자식 요소의 크기가 48\*48이지만, 부모 요소의 크기가 48\*53이 되어버림.
<img width="225" alt="스크린샷 2024-12-08 오전 11 44 49" src="https://github.com/user-attachments/assets/81426eb3-f255-4956-a57e-857ce2ec4520">
<img width="218" alt="스크린샷 2024-12-08 오전 11 45 14" src="https://github.com/user-attachments/assets/047bd50e-3e35-44d8-a2be-b9260215ec00">
**해결**
```
"& > svg": {
    verticalAlign: "middle",
  },
```
- `<svg>`는 인라인 요소로 처리되며, 라인박스에 의해 아래쪽에 추가적인 공간(아래 패딩처럼 보이는 여백)이 생깁니다.
- 이 현상은 브라우저가 텍스트의 글꼴 크기(font-size)와 라인 높이(line-height)를 기준으로 레이아웃을 계산하기 때문입니다.
- 이 여백은 "descender" 영역 때문으로, 글꼴의 문자가 포함될 가능성을 고려해 추가 공간을 할당합니다.
- `verticalAlign: "middle",`으로 이 문제를 해결