### PR TITLE
fix: 기본 폰트 변경

### DIFF
--- a/app/index.css
+++ b/app/index.css
@@ -109,7 +109,7 @@ body {
   line-height: 1.5;
   background-color: #fff; /* 기본 배경색 */
   color: #333; /* 기본 텍스트 색상 */
-  font-family: Arial, sans-serif; /* 기본 폰트 */
+  font-family: 'Noto Sans KR', sans-serif;
 }
 
 /* 리스트 스타일 제거 */


### PR DESCRIPTION
### 참고 사항
`preview-head.html` 파일에서 index.css를 먼저 로드한 뒤 globalStyes.css를 로드하는데,
두 파일에서 정의하는 body 태그의 폰트가 서로 달라 메인 페이지 로딩 시 폰트가 변경되는 문제가 있었습니다.
따라서 index.css의 body 태그에 선언된 기본 폰트를 Noto Sans로 변경했습니다.