### PR TITLE
fix: 커피 목록이 불러와지지 않는 버그

### DIFF
--- a/app/routes/logs.tsx
+++ b/app/routes/logs.tsx
@@ -11,12 +11,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
     data: { user },
   } = await supabase.auth.getUser();
   const userId = user?.id;
+  const token = user?.user_metadata.access_token;
 
   const {
     data: { coffeeCollection },
   } = await apolloClient.query<GetCoffeeListResponse>({
     query: GET_COFFEE_LIST_BY_USER_ID,
     variables: { userId },
+    context: {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
   });
 
   return { coffeeCollection };

--- a/src/api/coffee/query.ts
+++ b/src/api/coffee/query.ts
@@ -15,7 +15,7 @@ export type GetCoffeeListResponse = {
 };
 
 export const GET_COFFEE_LIST_BY_USER_ID = gql`
-  query GetCoffeeList($userId: BigInt!) {
+  query GetCoffeeList($userId: UUID!) {
     coffeeCollection(filter: { user_id: { eq: $userId } }) {
       edges {
         node {

--- a/src/apollo/client.ts
+++ b/src/apollo/client.ts
@@ -32,14 +32,14 @@ const httpLink = createHttpLink({
   uri: `${import.meta.env.VITE_SUPABASE_URL}/graphql/v1`,
 });
 
-const authLink = setContext(async (_, { headers }) => {
+const authLink = setContext(async (_, { headers, Authorization }) => {
   const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_KEY;
 
   return {
     headers: {
       ...headers,
       apikey: SUPABASE_KEY,
-      Authorization: `Bearer ${SUPABASE_KEY}`,
+      Authorization: Authorization || `Bearer ${SUPABASE_KEY}`,
     },
   };
 });


### PR DESCRIPTION
## 관련 이슈
#23 

## 버그 설명
서버의 요청에 헤더에 유저의 auth.id가 전달되지 않아 빈 배열이 오고 있었습니다.

## 작업 내용
- [x] ApolloClient를 사용할 때 Authorization header를 넣을 수 있도록 context를 추가.
- [x] 쿼리문의 userId 타입을 UUID로 변경
- [x] userId와 access token을 getUser를 통해 가져오도록 수정.

## getUser 사용 배경
기존엔 getSession을 사용해 token을 가져왔는데, 아래와 같은 경고 문구가 떴습니다.

```shell
# getSession과 onAuthStateChange를 통해 가져오는 user 객체는 안전하지 않다는 설명
Using the user object as returned from supabase.auth.getSession() or from some supabase.auth.onAuthStateChange() events could be insecure! This value comes directly from the storage medium (usually cookies on the server) and may not be authentic. Use supabase.auth.getUser() instead which authenticates the data by contacting the Supabase Auth server.
```

`supabase.auth.getSession()`이나 `supabase.auth.onAuthStateChange()`는 쿠키나 로컬스토리지에 저장된 user 정보를 가져온다고 합니다. 그런데 이것은 클라이언트 측에서 변조가 가능하기 때문에 실제로는 유효하지 않은 user 정보를 받고 있을 가능성이 있습니다.
반면 `supabase.auth.getUser()`는 supabase 인가 서버에 요청을 보내 검증을 하기 때문에 더 안전하다는 설명이었습니다.