### PR TITLE
feat: ActionHeader 컴포넌트 구현

### DIFF
--- a/app/component/ActionHeader/ActionHeader.stories.tsx
+++ b/app/component/ActionHeader/ActionHeader.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ActionHeader from '.';
+import { MdMoreVert } from 'react-icons/md';
+
+const meta: Meta<typeof ActionHeader> = {
+  title: 'Components/ActionHeader',
+  component: ActionHeader,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: '`ActionHeader`는 중앙 및 오른쪽 콘텐츠와 뒤로 가기 버튼을 포함한 헤더 컴포넌트입니다.',
+      },
+    },
+  },
+  argTypes: {
+    onBack: {
+      action: 'clicked',
+      description: '뒤로 가기 버튼 클릭 시 호출되는 함수입니다.',
+    },
+    children: {
+      description: '헤더에 렌더링할 `CenterContent`와 `RightContent`입니다.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 430 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '기본 상태',
+  args: {
+    children: [
+      <ActionHeader.CenterContent key={'center'}>중앙 텍스트</ActionHeader.CenterContent>,
+      <ActionHeader.RightContent key={'right'}>
+        <button>옵션</button>
+      </ActionHeader.RightContent>,
+    ],
+  },
+};
+
+export const WithoutRightContent: Story = {
+  name: '오른쪽 콘텐츠 없음',
+  args: {
+    children: <ActionHeader.CenterContent>중앙 텍스트만 표시</ActionHeader.CenterContent>,
+  },
+};
+
+export const CustomBackAction: Story = {
+  name: '커스텀 뒤로 가기 액션',
+  args: {
+    onBack: () => alert('뒤로 가기 버튼 클릭됨!'),
+    children: [
+      <ActionHeader.CenterContent key={'center'}>뒤로 가기 커스텀</ActionHeader.CenterContent>,
+      <ActionHeader.RightContent key={'right'}>
+        <button>설정</button>
+      </ActionHeader.RightContent>,
+    ],
+  },
+};
+
+export const DetailHeader: Story = {
+  name: 'Detail 페이지에서 사용될 헤더',
+  args: {
+    onBack: () => alert('뒤로 가기 버튼 클릭됨!'),
+    children: [
+      <ActionHeader.CenterContent key={'center'}>
+        <div>
+          <div>센터커피 서울숲점</div>
+          <div style={{ fontSize: '26px', fontWeight: 'bold' }}>아이스 드립커피</div>
+        </div>
+      </ActionHeader.CenterContent>,
+      <ActionHeader.RightContent key={'right'}>
+        <div style={{ position: 'relative', width: '18px', height: '24px' }}>
+          <MdMoreVert
+            style={{
+              left: '50%',
+              top: '50%',
+              transform: 'translate(-50%, -50%)',
+              position: 'absolute',
+              fontSize: '36px',
+            }}
+          />
+        </div>
+      </ActionHeader.RightContent>,
+    ],
+  },
+};

--- a/app/component/ActionHeader/index.tsx
+++ b/app/component/ActionHeader/index.tsx
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { PropsWithChildren } from 'react';
+import styles from './styles.css';
+import { MdOutlineChevronLeft } from 'react-icons/md';
+
+const CENTER_CONTENT_NAME = 'CenterContent';
+const RIGHT_CONTENT_NAME = 'RightContent';
+
+interface ActionHeaderProps {
+  onBack?: () => void;
+  children: React.ReactNode;
+}
+
+function ActionHeaderBase({ onBack, children }: ActionHeaderProps) {
+  const centerContent = React.Children.toArray(children).find(
+    (child: any) => child?.type?.displayName === CENTER_CONTENT_NAME
+  );
+
+  const rightContent = React.Children.toArray(children).find(
+    (child: any) => child?.type?.displayName === RIGHT_CONTENT_NAME
+  );
+
+  return (
+    <header className={styles.container}>
+      <button className={styles.leftButton} onClick={onBack}>
+        <MdOutlineChevronLeft className={styles.leftChevron} />
+      </button>
+      <div className={styles.centerContent}>{centerContent}</div>
+      <div className={styles.rightContent}>{rightContent}</div>
+    </header>
+  );
+}
+
+function CenterContent({ children }: PropsWithChildren) {
+  return <>{children}</>;
+}
+CenterContent.displayName = CENTER_CONTENT_NAME;
+
+function RightContent({ children }: PropsWithChildren) {
+  return <>{children}</>;
+}
+RightContent.displayName = RIGHT_CONTENT_NAME;
+
+const ActionHeader = Object.assign(ActionHeaderBase, {
+  CenterContent,
+  RightContent,
+});
+
+export default ActionHeader;

--- a/app/component/ActionHeader/index.tsx
+++ b/app/component/ActionHeader/index.tsx
@@ -11,7 +11,7 @@ interface ActionHeaderProps {
   children: React.ReactNode;
 }
 
-function ActionHeaderBase({ onBack, children }: ActionHeaderProps) {
+function ActionHeader({ onBack, children }: ActionHeaderProps) {
   const centerContent = React.Children.toArray(children).find(
     (child: any) => child?.type?.displayName === CENTER_CONTENT_NAME
   );
@@ -41,9 +41,7 @@ function RightContent({ children }: PropsWithChildren) {
 }
 RightContent.displayName = RIGHT_CONTENT_NAME;
 
-const ActionHeader = Object.assign(ActionHeaderBase, {
-  CenterContent,
-  RightContent,
-});
+ActionHeader.CenterContent = CenterContent;
+ActionHeader.RightContent = RightContent;
 
 export default ActionHeader;

--- a/app/component/ActionHeader/styles.css.ts
+++ b/app/component/ActionHeader/styles.css.ts
@@ -1,0 +1,42 @@
+import { style } from '@vanilla-extract/css';
+import { colors } from 'src/vanilla-extract/theme.css';
+
+const container = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+  height: '60px',
+  padding: '0 20px',
+});
+
+const leftButton = style({
+  all: 'unset',
+  position: 'relative',
+  width: '18px',
+  height: '100%',
+  cursor: 'pointer',
+});
+
+const leftChevron = style({
+  position: 'absolute',
+  left: '50%',
+  top: '50%',
+  transform: 'translate(-50%, -50%)',
+  fontSize: '58px',
+  color: colors.warmGray[800],
+});
+
+const centerContent = style({
+  flex: 1,
+  textAlign: 'center',
+});
+
+const rightContent = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+const styles = { container, leftButton, leftChevron, centerContent, rightContent };
+export default styles;


### PR DESCRIPTION
#25 
## 목적
- Create, Detail에서 사용되는 Header를 구현합니다.
- ActionHeader로 명명해봤습니다.

## 공유사항
- React Icons를 사용하였는데, 해당 아이콘은 Stroke 기반으로 제공되는 svg가 아니라서 굵기 조절이 어렵습니다. Material Design 소스를 사용했지만 피그마 디자인과 약간의 차이가 있습니다.
- Center와 right는 합성 컴포넌트 패턴을 통해서 받을 수 있게 구현하였지만, 뒤로가기 버튼의 경우 내부에서 구현해보았습니다. 이것도 합성 컴포넌트 패턴으로 구현하는 것이 좋을지 고민해봤습니다만, 추후에 재사용 될 가능성이 없을 것이라 판단하여 이렇게 일단 구현하였습니다. 의견 주세요!
- 스토리북 예제로 Detail 라우트에서 사용될 Header를 만들어 보았습니다. 활용 방법에 참고하시면 좋을 듯 합니다! 
![image](https://github.com/user-attachments/assets/b92c594f-cda9-468f-9fe3-1ce50cdbea45)
위는 피그마 디자인, 아래와 같이 구현할 수 있음. 스토리북 코드 확인하시면 됩니다!
<img width="435" alt="image" src="https://github.com/user-attachments/assets/71fd0818-cdca-481d-b103-66abdcf8e7aa" />

