### PR TITLE
feat: ImageUploader 컴포넌트 구현

### DIFF
--- a/app/component/ImageUploader/ImageUplodar.stories.tsx
+++ b/app/component/ImageUploader/ImageUplodar.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ImageUploader from '.';
+
+const meta: Meta<typeof ImageUploader> = {
+  title: 'Components/ImageUploader',
+  component: ImageUploader,
+  parameters: {
+    docs: {
+      description: {
+        component: '이미지를 업로드할 수 있는 버튼 컴포넌트입니다.',
+      },
+    },
+  },
+  argTypes: {
+    maxCount: {
+      control: { type: 'number' },
+      description: '업로드할 수 있는 최대 이미지 개수',
+      defaultValue: 5,
+    },
+    currentCount: {
+      control: { type: 'number' },
+      description: '현재 업로드된 이미지 개수',
+      defaultValue: 0,
+    },
+    onChange: { action: '파일 업로드됨', description: '파일 업로드 시 호출되는 핸들러' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    maxCount: 5,
+    currentCount: 0,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    maxCount: 5,
+    currentCount: 5,
+  },
+};

--- a/app/component/ImageUploader/index.tsx
+++ b/app/component/ImageUploader/index.tsx
@@ -10,7 +10,7 @@ interface ImageUploaderProps {
 }
 
 export default function ImageUploader({ maxCount, onChange, currentCount }: ImageUploaderProps) {
-  const disabled = currentCount === maxCount;
+  const disabled = currentCount >= maxCount;
   return (
     <div className={clsx(styles.container, disabled && styles.disabled)}>
       <MdOutlineCameraAlt className={styles.icon} />

--- a/app/component/ImageUploader/index.tsx
+++ b/app/component/ImageUploader/index.tsx
@@ -1,0 +1,23 @@
+import { typography } from 'src/vanilla-extract/typography.css';
+import styles from './styles.css';
+import { MdOutlineCameraAlt } from 'react-icons/md';
+import clsx from 'clsx';
+
+interface ImageUploaderProps {
+  maxCount: number;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  currentCount: number;
+}
+
+export default function ImageUploader({ maxCount, onChange, currentCount }: ImageUploaderProps) {
+  const disabled = currentCount === maxCount;
+  return (
+    <div className={clsx(styles.container, disabled && styles.disabled)}>
+      <MdOutlineCameraAlt className={styles.icon} />
+      <span className={typography.small}>
+        {currentCount} / {maxCount}
+      </span>
+      <input type="file" accept="image/*" multiple disabled={disabled} className={styles.input} onChange={onChange} />
+    </div>
+  );
+}

--- a/app/component/ImageUploader/styles.css.ts
+++ b/app/component/ImageUploader/styles.css.ts
@@ -1,0 +1,43 @@
+import { style } from '@vanilla-extract/css';
+import { colors } from 'src/vanilla-extract/theme.css';
+
+const container = style({
+  position: 'relative',
+  width: '80px',
+  aspectRatio: '1/1',
+
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+
+  backgroundColor: colors.warmGray[100],
+  borderRadius: '2px',
+
+  color: colors.warmGray[800],
+});
+
+const icon = style({
+  fontSize: '24px',
+});
+
+const input = style({
+  position: 'absolute',
+  width: '100%',
+  height: '100%',
+  opacity: 0,
+  cursor: 'pointer',
+});
+
+const disabled = style({
+  color: colors.warmGray[400],
+});
+
+const styles = {
+  container,
+  icon,
+  input,
+  disabled,
+};
+
+export default styles;


### PR DESCRIPTION
## 구현 목록
- [x] ImageUploader 컴포넌트 구현
- [x] ImageUploader 스토리북 구현

## 참고사항
- ImageUploader컴포넌트는 Input type='file'의 역할을 하는 input의 역할을 하지만, 공통적인 input의 역할은 하지 않는 제한적인 컴포넌트입니다. 따라서 input의 props을 내려받지 않도록 설계하였습니다. 
- 해당 컴포넌트는 ios환경에선 다음과 같이 나타납니다.
<img width="270" alt="image" src="https://github.com/user-attachments/assets/a03715fd-787a-42a7-bf0e-4b6c7a26a9ca" />

- #33 
