### PR TITLE
feat: 점수 슬라이더 컴포넌트 구현

### DIFF
--- a/app/component/CoffeeScoreSlider/CoffeeScoreSlider.stories.tsx
+++ b/app/component/CoffeeScoreSlider/CoffeeScoreSlider.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CoffeeScoreSlider from '.';
+
+const meta: Meta<typeof CoffeeScoreSlider> = {
+  title: 'Components/CoffeeScoreSlider',
+  component: CoffeeScoreSlider,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: '',
+      },
+    },
+  },
+  argTypes: {},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: '기본 상태',
+  args: {},
+};

--- a/app/component/CoffeeScoreSlider/CoffeeScoreSlider.stories.tsx
+++ b/app/component/CoffeeScoreSlider/CoffeeScoreSlider.stories.tsx
@@ -21,5 +21,5 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: '기본 상태',
-  args: { sid: 'flavor' },
+  args: { title: 'flavor' },
 };

--- a/app/component/CoffeeScoreSlider/CoffeeScoreSlider.stories.tsx
+++ b/app/component/CoffeeScoreSlider/CoffeeScoreSlider.stories.tsx
@@ -21,5 +21,5 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: '기본 상태',
-  args: {},
+  args: { sid: 'flavor' },
 };

--- a/app/component/CoffeeScoreSlider/index.tsx
+++ b/app/component/CoffeeScoreSlider/index.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import * as styles from './style.css';
+import clsx from 'clsx';
+
+export default function CoffeeScoreSlider() {
+  const [score, setScore] = useState(5);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(event.target.value, 10);
+    setScore(value);
+  };
+
+  return (
+    <section className={styles.scoreDialContainer} aria-label="점수 선택기">
+      <div className={styles.tuningScale}>
+        {[...Array(11)].map((_, i) => {
+          const size = i % 5 === 0 ? 'large' : 'small';
+          return (
+            <div key={i} className={styles.markContainer}>
+              {i === score && <div className={styles.pointer} />}
+              <div className={clsx(styles.mark[size], i === score && styles.selectedMark)} />
+              <div className={clsx(styles.number, i === score && styles.selectedNumber)}>{i}</div>
+            </div>
+          );
+        })}
+      </div>
+
+      <input
+        type="range"
+        min="0"
+        max="10"
+        step="1"
+        value={score}
+        onChange={handleChange}
+        className={styles.rangeInput}
+        aria-valuemin={0}
+        aria-valuemax={10}
+        aria-valuenow={score}
+      />
+    </section>
+  );
+}

--- a/app/component/CoffeeScoreSlider/index.tsx
+++ b/app/component/CoffeeScoreSlider/index.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { typography } from 'src/vanilla-extract/typography.css';
 
 interface CoffeeScoreSliderProps {
-  sid: 'flavor' | 'sweetness' | 'acidity' | 'balance' | 'overall';
+  title: 'flavor' | 'sweetness' | 'acidity' | 'balance' | 'overall';
 }
 
 const TITLE = {
@@ -15,7 +15,7 @@ const TITLE = {
   overall: '종합',
 };
 
-export default function CoffeeScoreSlider({ sid }: CoffeeScoreSliderProps) {
+export default function CoffeeScoreSlider({ title }: CoffeeScoreSliderProps) {
   const [score, setScore] = useState(5);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -26,10 +26,12 @@ export default function CoffeeScoreSlider({ sid }: CoffeeScoreSliderProps) {
   return (
     <section className={styles.scoreDialContainer} aria-label="점수 선택기">
       <div className={styles.labelContainer}>
-        <label htmlFor={sid} className={typography.heading2}>
-          {TITLE[sid]}
+        <label htmlFor={title} className={typography.heading2}>
+          {TITLE[title]}
         </label>
-        <span className={clsx(styles.labelDescription, typography.small)}>{sid[0].toUpperCase() + sid.slice(1)}</span>
+        <span className={clsx(styles.labelDescription, typography.small)}>
+          {title[0].toUpperCase() + title.slice(1)}
+        </span>
       </div>
 
       <div style={{ width: '100%', position: 'relative' }}>
@@ -39,7 +41,7 @@ export default function CoffeeScoreSlider({ sid }: CoffeeScoreSliderProps) {
             return (
               <div key={i} className={styles.markContainer}>
                 {i === score && <div className={styles.pointer} />}
-                <div className={clsx(styles.mark[size], i === score && styles.selectedMark)} />
+                <div className={clsx(styles.mark[size], i <= score && styles.selectedMark)} />
                 <div className={clsx(styles.number, i === score && styles.selectedNumber)}>{i}</div>
               </div>
             );
@@ -51,7 +53,7 @@ export default function CoffeeScoreSlider({ sid }: CoffeeScoreSliderProps) {
           min="0"
           max="10"
           step="1"
-          id={sid}
+          id={title}
           value={score}
           onChange={handleChange}
           className={styles.rangeInput}

--- a/app/component/CoffeeScoreSlider/index.tsx
+++ b/app/component/CoffeeScoreSlider/index.tsx
@@ -32,7 +32,7 @@ export default function CoffeeScoreSlider({ sid }: CoffeeScoreSliderProps) {
         <span className={clsx(styles.labelDescription, typography.small)}>{sid[0].toUpperCase() + sid.slice(1)}</span>
       </div>
 
-      <div style={{ width: '100%', position: 'relative', height: '64px' }}>
+      <div style={{ width: '100%', position: 'relative' }}>
         <div className={styles.tuningScale}>
           {[...Array(11)].map((_, i) => {
             const size = i % 5 === 0 ? 'large' : 'small';

--- a/app/component/CoffeeScoreSlider/index.tsx
+++ b/app/component/CoffeeScoreSlider/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import * as styles from './style.css';
+import { styles } from './style.css';
 import clsx from 'clsx';
 import { typography } from 'src/vanilla-extract/typography.css';
 

--- a/app/component/CoffeeScoreSlider/index.tsx
+++ b/app/component/CoffeeScoreSlider/index.tsx
@@ -32,31 +32,34 @@ export default function CoffeeScoreSlider({ sid }: CoffeeScoreSliderProps) {
         <span className={clsx(styles.labelDescription, typography.small)}>{sid[0].toUpperCase() + sid.slice(1)}</span>
       </div>
 
-      <div className={styles.tuningScale}>
-        {[...Array(11)].map((_, i) => {
-          const size = i % 5 === 0 ? 'large' : 'small';
-          return (
-            <div key={i} className={styles.markContainer}>
-              {i === score && <div className={styles.pointer} />}
-              <div className={clsx(styles.mark[size], i === score && styles.selectedMark)} />
-              <div className={clsx(styles.number, i === score && styles.selectedNumber)}>{i}</div>
-            </div>
-          );
-        })}
+      <div style={{ width: '100%', position: 'relative', height: '64px' }}>
+        <div className={styles.tuningScale}>
+          {[...Array(11)].map((_, i) => {
+            const size = i % 5 === 0 ? 'large' : 'small';
+            return (
+              <div key={i} className={styles.markContainer}>
+                {i === score && <div className={styles.pointer} />}
+                <div className={clsx(styles.mark[size], i === score && styles.selectedMark)} />
+                <div className={clsx(styles.number, i === score && styles.selectedNumber)}>{i}</div>
+              </div>
+            );
+          })}
+        </div>
+
+        <input
+          type="range"
+          min="0"
+          max="10"
+          step="1"
+          id={sid}
+          value={score}
+          onChange={handleChange}
+          className={styles.rangeInput}
+          aria-valuemin={0}
+          aria-valuemax={10}
+          aria-valuetext={`${score}점`}
+        />
       </div>
-      <input
-        type="range"
-        min="0"
-        max="10"
-        step="1"
-        id={sid}
-        value={score}
-        onChange={handleChange}
-        className={styles.rangeInput}
-        aria-valuemin={0}
-        aria-valuemax={10}
-        aria-valuetext={`${score}점`}
-      />
     </section>
   );
 }

--- a/app/component/CoffeeScoreSlider/index.tsx
+++ b/app/component/CoffeeScoreSlider/index.tsx
@@ -1,17 +1,37 @@
 import { useState } from 'react';
 import * as styles from './style.css';
 import clsx from 'clsx';
+import { typography } from 'src/vanilla-extract/typography.css';
 
-export default function CoffeeScoreSlider() {
+interface CoffeeScoreSliderProps {
+  sid: 'flavor' | 'sweetness' | 'acidity' | 'balance' | 'overall';
+}
+
+const TITLE = {
+  flavor: '향미',
+  sweetness: '단맛',
+  acidity: '산미',
+  balance: '밸런스',
+  overall: '종합',
+};
+
+export default function CoffeeScoreSlider({ sid }: CoffeeScoreSliderProps) {
   const [score, setScore] = useState(5);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = parseInt(event.target.value, 10);
+    const value = parseInt(event.target.value);
     setScore(value);
   };
 
   return (
     <section className={styles.scoreDialContainer} aria-label="점수 선택기">
+      <div className={styles.labelContainer}>
+        <label htmlFor={sid} className={typography.heading2}>
+          {TITLE[sid]}
+        </label>
+        <span className={clsx(styles.labelDescription, typography.small)}>{sid[0].toUpperCase() + sid.slice(1)}</span>
+      </div>
+
       <div className={styles.tuningScale}>
         {[...Array(11)].map((_, i) => {
           const size = i % 5 === 0 ? 'large' : 'small';
@@ -24,18 +44,18 @@ export default function CoffeeScoreSlider() {
           );
         })}
       </div>
-
       <input
         type="range"
         min="0"
         max="10"
         step="1"
+        id={sid}
         value={score}
         onChange={handleChange}
         className={styles.rangeInput}
         aria-valuemin={0}
         aria-valuemax={10}
-        aria-valuenow={score}
+        aria-valuetext={`${score}점`}
       />
     </section>
   );

--- a/app/component/CoffeeScoreSlider/style.css.ts
+++ b/app/component/CoffeeScoreSlider/style.css.ts
@@ -1,0 +1,78 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+import { colors } from 'src/vanilla-extract/theme.css';
+
+export const scoreDialContainer = style({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  borderRadius: '8px',
+  textAlign: 'center',
+  width: '300px',
+});
+
+export const tuningScale = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'flex-end',
+  width: '100%',
+  padding: '0 10px',
+});
+
+export const markContainer = style({
+  position: 'relative',
+  height: '62px',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  textAlign: 'center',
+});
+
+export const pointer = style({
+  position: 'absolute',
+  top: '-12px',
+  left: '50%',
+  width: '0',
+  height: '0',
+  borderLeft: '4px solid transparent',
+  borderRight: '4px solid transparent',
+  borderBottom: `6px solid ${colors.base.orange}`,
+  transform: 'translateX(-50%) rotate(180deg)',
+});
+
+export const markBase = style({
+  width: '2px',
+  transition: 'background 0.2s',
+});
+
+export const mark = styleVariants({
+  small: [markBase, { height: '24px', background: colors.warmGray[300], marginTop: '70%' }],
+  large: [markBase, { height: '100%', width: '3px', marginTop: '0', backgroundColor: colors.warmGray[500] }],
+});
+
+export const selectedMark = style({
+  backgroundColor: colors.base.orange,
+});
+
+export const number = style({
+  fontSize: '14px',
+  marginTop: '5px',
+  color: colors.warmGray[400],
+});
+
+export const selectedNumber = style({
+  color: colors.warmGray[900],
+});
+
+export const rangeInput = style({
+  position: 'absolute',
+  width: '100%',
+  height: '100%',
+  appearance: 'none',
+  MozAppearance: 'none',
+  WebkitAppearance: 'none',
+  background: 'transparent',
+  opacity: 0,
+  cursor: 'pointer',
+});

--- a/app/component/CoffeeScoreSlider/style.css.ts
+++ b/app/component/CoffeeScoreSlider/style.css.ts
@@ -3,7 +3,6 @@ import { colors } from 'src/vanilla-extract/theme.css';
 import { typography } from 'src/vanilla-extract/typography.css';
 
 export const scoreDialContainer = style({
-  position: 'relative',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
@@ -81,12 +80,25 @@ export const selectedNumber = style({
 
 export const rangeInput = style({
   position: 'absolute',
+  top: 0,
+  left: 0,
   width: '100%',
-  height: '100%',
-  appearance: 'none',
-  MozAppearance: 'none',
-  WebkitAppearance: 'none',
+  height: '64px',
+  zIndex: 1,
   background: 'transparent',
   opacity: 0,
   cursor: 'pointer',
+
+  selectors: {
+    '&::-webkit-slider-thumb': {
+      width: '36px',
+      height: '36px',
+      background: 'transparent',
+    },
+    '&::-moz-range-thumb': {
+      width: '36px',
+      height: '36px',
+      background: 'transparent',
+    },
+  },
 });

--- a/app/component/CoffeeScoreSlider/style.css.ts
+++ b/app/component/CoffeeScoreSlider/style.css.ts
@@ -76,6 +76,8 @@ export const number = style({
 
 export const selectedNumber = style({
   color: colors.warmGray[900],
+  transform: 'scale(1.2)',
+  transition: 'transform 0.2s',
 });
 
 export const rangeInput = style({

--- a/app/component/CoffeeScoreSlider/style.css.ts
+++ b/app/component/CoffeeScoreSlider/style.css.ts
@@ -85,6 +85,7 @@ export const rangeInput = style({
   top: 0,
   left: 0,
   width: '100%',
+  height: '100%',
   zIndex: 1,
   background: 'transparent',
   opacity: 0,

--- a/app/component/CoffeeScoreSlider/style.css.ts
+++ b/app/component/CoffeeScoreSlider/style.css.ts
@@ -1,5 +1,6 @@
 import { style, styleVariants } from '@vanilla-extract/css';
 import { colors } from 'src/vanilla-extract/theme.css';
+import { typography } from 'src/vanilla-extract/typography.css';
 
 export const scoreDialContainer = style({
   position: 'relative',
@@ -11,12 +12,25 @@ export const scoreDialContainer = style({
   width: '300px',
 });
 
+export const labelContainer = style({
+  width: '100%',
+  display: 'flex',
+  alignItems: 'flex-end',
+  gap: '3px',
+  marginBottom: '20px',
+  color: colors.warmGray[900],
+});
+
+export const labelDescription = style({
+  fontSize: typography.small,
+  color: colors.warmGray[700],
+});
+
 export const tuningScale = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'flex-end',
   width: '100%',
-  padding: '0 10px',
 });
 
 export const markContainer = style({

--- a/app/component/CoffeeScoreSlider/style.css.ts
+++ b/app/component/CoffeeScoreSlider/style.css.ts
@@ -85,7 +85,7 @@ export const rangeInput = style({
   width: '100%',
   zIndex: 1,
   background: 'transparent',
-  // opacity: 0,
+  opacity: 0,
   cursor: 'pointer',
 
   selectors: {

--- a/app/component/CoffeeScoreSlider/style.css.ts
+++ b/app/component/CoffeeScoreSlider/style.css.ts
@@ -2,7 +2,7 @@ import { style, styleVariants } from '@vanilla-extract/css';
 import { colors } from 'src/vanilla-extract/theme.css';
 import { typography } from 'src/vanilla-extract/typography.css';
 
-export const scoreDialContainer = style({
+const scoreDialContainer = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
@@ -11,7 +11,7 @@ export const scoreDialContainer = style({
   width: '300px',
 });
 
-export const labelContainer = style({
+const labelContainer = style({
   width: '100%',
   display: 'flex',
   alignItems: 'flex-end',
@@ -20,19 +20,19 @@ export const labelContainer = style({
   color: colors.warmGray[900],
 });
 
-export const labelDescription = style({
+const labelDescription = style({
   fontSize: typography.small,
   color: colors.warmGray[700],
 });
 
-export const tuningScale = style({
+const tuningScale = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'flex-end',
   width: '100%',
 });
 
-export const markContainer = style({
+const markContainer = style({
   position: 'relative',
   height: '62px',
   display: 'flex',
@@ -42,7 +42,7 @@ export const markContainer = style({
   textAlign: 'center',
 });
 
-export const pointer = style({
+const pointer = style({
   position: 'absolute',
   top: '-12px',
   left: '50%',
@@ -54,33 +54,33 @@ export const pointer = style({
   transform: 'translateX(-50%) rotate(180deg)',
 });
 
-export const markBase = style({
+const markBase = style({
   width: '2px',
   transition: 'background 0.2s',
 });
 
-export const mark = styleVariants({
+const mark = styleVariants({
   small: [markBase, { height: '24px', background: colors.warmGray[300], marginTop: '70%' }],
   large: [markBase, { height: '100%', width: '3px', marginTop: '0', backgroundColor: colors.warmGray[500] }],
 });
 
-export const selectedMark = style({
+const selectedMark = style({
   backgroundColor: colors.base.orange,
 });
 
-export const number = style({
+const number = style({
   fontSize: '14px',
   marginTop: '5px',
   color: colors.warmGray[400],
 });
 
-export const selectedNumber = style({
+const selectedNumber = style({
   color: colors.warmGray[900],
   transform: 'scale(1.2)',
   transition: 'transform 0.2s',
 });
 
-export const rangeInput = style({
+const rangeInput = style({
   position: 'absolute',
   top: 0,
   left: 0,
@@ -104,3 +104,17 @@ export const rangeInput = style({
     },
   },
 });
+
+export const styles = {
+  scoreDialContainer,
+  labelContainer,
+  labelDescription,
+  tuningScale,
+  markContainer,
+  pointer,
+  mark,
+  selectedMark,
+  number,
+  selectedNumber,
+  rangeInput,
+};

--- a/app/component/CoffeeScoreSlider/style.css.ts
+++ b/app/component/CoffeeScoreSlider/style.css.ts
@@ -83,10 +83,9 @@ export const rangeInput = style({
   top: 0,
   left: 0,
   width: '100%',
-  height: '64px',
   zIndex: 1,
   background: 'transparent',
-  opacity: 0,
+  // opacity: 0,
   cursor: 'pointer',
 
   selectors: {

--- a/src/vanilla-extract/theme.css.ts
+++ b/src/vanilla-extract/theme.css.ts
@@ -1,10 +1,11 @@
-import { createTheme, createThemeContract } from "@vanilla-extract/css";
+import { createTheme, createThemeContract } from '@vanilla-extract/css';
 
 export const colors = createThemeContract({
   base: {
     primary: null,
     black: null,
     white: null,
+    orange: null,
   },
   warmGray: {
     100: null,
@@ -32,30 +33,31 @@ export const colors = createThemeContract({
 
 export const defaultTheme = createTheme(colors, {
   base: {
-    primary: "#DE4B18",
-    black: "#12100E",
-    white: "#F7F6F4",
+    primary: '#DE4B18',
+    black: '#12100E',
+    white: '#F7F6F4',
+    orange: '#DE4B18',
   },
   warmGray: {
-    100: "#EFEDEA",
-    200: "#D9D5CE",
-    300: "#C4BDB2",
-    400: "#AFA597",
-    500: "#998D7B",
-    600: "#766F69",
-    700: "#655B4E",
-    800: "#494238",
-    900: "#2E2923",
+    100: '#EFEDEA',
+    200: '#D9D5CE',
+    300: '#C4BDB2',
+    400: '#AFA597',
+    500: '#998D7B',
+    600: '#766F69',
+    700: '#655B4E',
+    800: '#494238',
+    900: '#2E2923',
   },
   blueScale: {
-    100: "#D9E4ED",
-    200: "#B3C9DB",
-    300: "#8CADC8",
-    400: "#6692B6",
-    500: "#4077A4",
-    600: "#35658D",
-    700: "#2A5376",
-    800: "#204260",
-    900: "#153049",
+    100: '#D9E4ED',
+    200: '#B3C9DB',
+    300: '#8CADC8',
+    400: '#6692B6',
+    500: '#4077A4',
+    600: '#35658D',
+    700: '#2A5376',
+    800: '#204260',
+    900: '#153049',
   },
 });


### PR DESCRIPTION
## 구현 결과
![slider](https://github.com/user-attachments/assets/7e568959-9f5f-4408-891f-34e0e7aa88ce)

## 참고사항
네이티브 input의 기능을 사용하기 위해 opacity를 0으로 처리해 삽입했습니다. safari, chrome, 모바일 safari 모두 보이지 않는 것을 확인했는데, 혹시나 러기 환경에서 스타일이 깨지거나 잘 동작하지 않는다면 말씀해 주세요!

## 의논하고 싶은 것
모바일과 데스크탑에서 input range를 드래그로 조작할 때 동작이 조금 달라요.
데스크탑은 thumb(현재 점수를 가리키는 indicator)을 벗어나 드래그를 시작해도 의도한대로 점수가 반영되는 반면, 모바일은 무조건 thumb을 잡고 끌어야 합니다.
#### [동영상 설명(데스크탑)]
![desktop](https://github.com/user-attachments/assets/4a41486f-2467-4f28-aa94-92ab585743f0)

그래서 모바일 사용자가 이 컴포넌트가 슬라이더라는 사실을 알아차리지 못할 가능성이 크다고 생각했어요. 결론적으로 모바일에서의 편의를 위해 정확하게 range가 차는 UI 형태로 변경하는 것에 대해서 어떻게 생각하는지 러기의 의견이 궁금합니당.

#### 게이지 형식(좀 안 예쁘긴 함..)

https://github.com/user-attachments/assets/0c4c08e0-4465-4960-b400-ee8720ab5b29

